### PR TITLE
fixing location of metadata json

### DIFF
--- a/gnomehub@gnome-hub.github.io/metadata.json
+++ b/gnomehub@gnome-hub.github.io/metadata.json
@@ -1,8 +1,9 @@
 {
-  "name": "gnomehub",
-  "description": "Display a panel on the notification bar giving controls and information",
-  "uuid": "gnomehub@gnome-hub.github.io",
-  "shell-version": [
-    "3.36"
-  ]
+    "uuid": "gnomehub@gnome-hub.github.io",
+    "name": "gnomehub",
+    "description": "An all in one extension which catagorizes notifications and displays system information",
+    "version": 1,
+    "shell-version": [ "3.38", "40", "41.alpha" ],
+    "url": "https://gnome-hub.github.io/",
+    "session-modes":  [ "unlock-dialog", "user" ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,9 +1,0 @@
-{
-    "uuid": "gnomehub@gnome-hub.github.io",
-    "name": "gnomehub",
-    "description": "An all in one extension which catagorizes notifications and displays system information",
-    "version": 1,
-    "shell-version": [ "3.38", "40", "41.alpha" ],
-    "url": "https://gnome-hub.github.io/",
-    "session-modes":  [ "unlock-dialog", "user" ]
-}


### PR DESCRIPTION
Required for adding to gnome shell extension store